### PR TITLE
Java tutorial uses internal integrations.

### DIFF
--- a/java/command/README.md
+++ b/java/command/README.md
@@ -12,8 +12,9 @@ app](https://get.slack.help/hc/en-us/articles/204714258-Add-Giphy-search-to-Slac
 2\.  [Costs](#costs)  
 3\.  [Before you begin](#beforeyoubegin)  
 4\.  [Getting the sample code](#gettingthesamplecode)  
-5\.  [Before you begin](#beforeyoubegin-1)  
-6\.  [Adding a slash command custom integration](#addingaslashcommandcustomintegration)  
+5\.  [Deploying to App Engine](#deployingtoappengine)  
+6\.  [Create a Slack app](#createaslackapp)  
+7\.  [Adding a slash command custom integration](#addingaslashcommandcustomintegration)  
 
 <a name="objectives"></a>
 
@@ -73,37 +74,61 @@ modify to support Slack slash commands.
 
     cd java/command/1-start
 
-<a name="beforeyoubegin-1"></a>
+<a name="deployingtoappengine"></a>
 
-## 5\. Before you begin
+## 5\. Deploying to App Engine
 
-1.  Follow the [quickstart for Java in the App Engine flexible
-    environment](https://cloud.google.com/appengine/docs/flexible/java/quickstart) to 
-    set up your environment to deploy the sample applications App Engine.
-    1.  Download and install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/).
-    1.  [Install and configure Apache Maven](http://maven.apache.org/index.html).
-    1.  [Create a new Google Cloud Platform project, or use an existing
-        one](https://console.cloud.google.com/project).
-    1.  [Enable billing for your
-        project](https://support.google.com/cloud/answer/6293499#enable-billing).
-    1. Initialize the Cloud SDK.
+To run the application locally, use the Maven Jetty plugin.
 
-           gcloud init
+    mvn clean jetty:run-exploded
+
+View the app at [localhost:8080](http://localhost:8080).
+
+To deploy the app to App Engine, run
+
+    mvn clean appengine:deploy
+
+After the deploy finishes (can take up to 10 minutes), you can view your application at
+`https://YOUR_PROJECT.appspot.com`, where `YOUR_PROJECT` is your Google Cloud project ID. You can
+see the new version deployed on the [App Engine section of the Google Cloud
+Console](https://console.cloud.google.com/appengine/versions).
+
+For a more detailed walkthrough, see the [getting started
+guide for Java in the App Engine flexible
+environment](https://cloud.google.com/java/getting-started/hello-world).
+
+
+<a name="createaslackapp"></a>
+
+## 6\. Create a Slack app
+
+Create a new Slack app by going to the [app management
+page](https://api.slack.com/apps) and clicking the **Create new app** button.
+
+1.  Give the app a name, such as "Hello World".
+1.  Choose the Slack team where you want it installed.
 
 <a name="addingaslashcommandcustomintegration"></a>
 
-## 6\. Adding a slash command custom integration
+## 7\. Adding a slash command custom integration
 
 When someone types a [slash command in
 Slack](https://api.slack.com/slash-commands#how_do_commands_work), the Slack servers send an HTTP
 request to your application.
 
--   Add a slash command custom integration to your Slack team from the [custom integrations
-    management page](https://slack.com/apps/manage/custom-integrations).
--   Use `/greet` as the command name.
--   Set the URL on the integration settings page to the URL for your deployed application (for
-    example: `https://YOUR_PROJECT.appspot.com/send-greeting`).
--   Click the Save button at the bottom of the page to save your settings.
+1.  Select the [Slash commands](https://api.slack.com/slash-commands) feature
+    in the **Add features and functionality** section.
+1.  Click the **Create new command** button.
+1.  Set the command name to `/greet`.
+1.  Set the request URL to `https://YOUR_PROJECT.appspot.com/send-greeting`,
+    replacing `YOUR_PROJECT` with your Google Cloud Project ID.
+1.  Set the short description to "Sends a greeting".
+1.  Click the **Save** button at the bottom of the page to save your settings.
+
+Reinstall the app to ensure the slash command is installed.
+
+1.  Select the **Install app** item in the left navigation under **Settings**.
+1.  Click the **Install app** or **Reinstall app** button.
     
 When you run the slash command, Slack will send a request to your app and show the result.
 

--- a/java/command/README.mdpp
+++ b/java/command/README.mdpp
@@ -29,7 +29,7 @@ Use the [Pricing Calculator][pricing] to generate a cost estimate based on your 
 
 [pricing]: https://cloud.google.com/products/calculator
 
-!INCLUDEURL "https://raw.githubusercontent.com/GoogleCloudPlatform/java-docs-samples/tswast-readmetemplates/.github/templates/appengine-flexible-before-you-begin.mdpp"
+!INCLUDEURL "https://raw.githubusercontent.com/GoogleCloudPlatform/java-docs-samples/master/.github/templates/appengine-flexible-before-you-begin.mdpp"
 
 1.  Create a [new Slack team](https://slack.com/), or use an team where you have
     permissions to add custom integrations.
@@ -41,7 +41,15 @@ modify to support Slack slash commands.
 
     cd java/command/1-start
 
-!INCLUDEURL "https://raw.githubusercontent.com/GoogleCloudPlatform/java-docs-samples/tswast-readmetemplates/.github/templates/appengine-flexible-before-you-begin.mdpp"
+!INCLUDEURL "https://raw.githubusercontent.com/GoogleCloudPlatform/java-docs-samples/master/.github/templates/appengine-flexible-deploy.mdpp"
+
+## Create a Slack app
+
+Create a new Slack app by going to the [app management
+page](https://api.slack.com/apps) and clicking the **Create new app** button.
+
+1.  Give the app a name, such as "Hello World".
+1.  Choose the Slack team where you want it installed.
 
 ## Adding a slash command custom integration
 
@@ -49,12 +57,19 @@ When someone types a [slash command in
 Slack](https://api.slack.com/slash-commands#how_do_commands_work), the Slack servers send an HTTP
 request to your application.
 
--   Add a slash command custom integration to your Slack team from the [custom integrations
-    management page](https://slack.com/apps/manage/custom-integrations).
--   Use `/greet` as the command name.
--   Set the URL on the integration settings page to the URL for your deployed application (for
-    example: `https://YOUR_PROJECT.appspot.com/send-greeting`).
--   Click the Save button at the bottom of the page to save your settings.
+1.  Select the [Slash commands](https://api.slack.com/slash-commands) feature
+    in the **Add features and functionality** section.
+1.  Click the **Create new command** button.
+1.  Set the command name to `/greet`.
+1.  Set the request URL to `https://YOUR_PROJECT.appspot.com/send-greeting`,
+    replacing `YOUR_PROJECT` with your Google Cloud Project ID.
+1.  Set the short description to "Sends a greeting".
+1.  Click the **Save** button at the bottom of the page to save your settings.
+
+Reinstall the app to ensure the slash command is installed.
+
+1.  Select the **Install app** item in the left navigation under **Settings**.
+1.  Click the **Install app** or **Reinstall app** button.
     
 When you run the slash command, Slack will send a request to your app and show the result.
 


### PR DESCRIPTION
Update the slash command tutorial to use internal integrations instead
of custom integrations.

To generate the README.md from README.mdpp, I ran
`markdown-pp README.mdpp -o README.md`